### PR TITLE
Test card number checking

### DIFF
--- a/lib/cc_validation.ex
+++ b/lib/cc_validation.ex
@@ -3,6 +3,34 @@ defmodule CcValidation do
   CcValidation implements methods to verify validity of a credit card number
   """
 
+  def validate(number, check_test_numbers \\ false)
+
+  @doc """
+  Validate test card numbers when check_test_numbers is true
+
+  A valid test card
+      iex> CcValidation.validate("4111111111111111", true)
+      {:ok, true, test_number: true}
+
+  An invalid test card
+      iex> CcValidation.validate("4212121212121212", true)
+      {:error, false, test_number: false}
+
+  A valid card when checking for test numbers just passes through
+  to the validate function but will also return that it is not
+  a test card
+      iex> CcValidation.validate("4716892095589823", true)
+      {:ok, true, test_number: false}
+  """
+  def validate(number, true) do
+    case CcValidation.TestNumbers.has_number?(number) do
+      true ->
+        {:ok, true, test_number: true}
+      false ->
+        Tuple.append(validate(number), test_number: false)
+    end
+  end
+
   @doc """
   Card numbers that are of length less than 13 or greater than 19 are invalid.
 
@@ -14,7 +42,7 @@ defmodule CcValidation do
       iex> CcValidation.validate("12345678901234567890")
       {:error, false}
   """
-  def validate(number)
+  def validate(number, false)
     when byte_size(number) < 13 or byte_size(number) > 19 do
       {:error, false}
   end
@@ -32,7 +60,7 @@ defmodule CcValidation do
       iex> CcValidation.validate("4024007106963134")
       {:error, false}
   """
-  def validate(number) do
+  def validate(number, false) do
     total = String.codepoints(number)
     |> Enum.reverse
     |> Stream.with_index

--- a/lib/cc_validation/test_numbers.ex
+++ b/lib/cc_validation/test_numbers.ex
@@ -1,0 +1,40 @@
+defmodule CcValidation.TestNumbers do
+  @moduledoc """
+  CcValidation.TestNumbers contains test card numbers to validate against
+  as a valid card number
+  """
+
+  @numbers %{
+    "378282246310005": "American Express",
+    "371449635398431": "American Express",
+    "378734493671000": "American Express Corporate",
+    "5610591081018250": "Australian BankCard",
+    "30569309025904": "Diners Club",
+    "38520000023237": "Diners Club",
+    "6011111111111117": "Discover",
+    "6011000990139424": "Discover",
+    "3530111333300000": "JCB",
+    "3566002020360505": "JCB",
+    "5555555555554444": "MasterCard",
+    "5105105105105100": "MasterCard",
+    "4111111111111111": "Visa",
+    "4012888888881881": "Visa",
+    "4222222222222": "Visa"
+  }
+
+
+  @doc """
+  Check that a number is a valid test number or not
+
+  A valid test card
+      iex> CcValidation.TestNumbers.has_number?("4111111111111111")
+      true
+
+  An invalid test card
+      iex> CcValidation.TestNumbers.has_number?("4212121212121212")
+      false
+  """
+  def has_number?(number) do
+    Map.has_key? @numbers, :"#{number}"
+  end
+end

--- a/test/cc_validation/test_numbers_test.exs
+++ b/test/cc_validation/test_numbers_test.exs
@@ -1,0 +1,4 @@
+defmodule CcValidation.TestNumbersTest do
+  use ExUnit.Case
+  doctest CcValidation.TestNumbers
+end


### PR DESCRIPTION
## What

Check for test numbers as valid or not.

## Changes

- Add a `CcValidation.TestNumbers` module
- Update `validate` to include check for test numbers
- Default to not checking test numbers
- Fall through to validate if checking a test number and it is invalid